### PR TITLE
Fix typos and license information

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Nordic Health Data
+Copyright (c) 2015 - 2016 Nordic Health Data
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/readme.md
+++ b/readme.md
@@ -1,98 +1,108 @@
-## Simple search portal frontend for Elastic Search
+## Simple search portal frontend for Elasticsearch
 
-This is a an search portal built using Laravel 5.1 for interfacing with Elastic Search
-
-[Laravel documentation](https://laravel.com/docs/5.1).
+This is a search portal built using [Laravel 5.1](https://laravel.com/docs/5.1) for interfacing with [Elasticsearch](https://www.elastic.co/products/elasticsearch).
 
 ## 1. Requirements
 
 * PHP (5.5.9 or later)
 * Composer https://getcomposer.org (to install/update packages)
-* Running instance or cluster of Eleasticsearch https://www.elastic.co/products/elasticsearch (requires Java)
+* Running instance or cluster of Elasticsearch https://www.elastic.co/products/elasticsearch (requires Java)
 
 ## 2. Setup
 
-__a.__ Clone this repository (using git)
+__a.__ Clone this repository
 
-__b.__ Install packages using composer
-   Navigate to the project folder and run:
+```
+git clone https://github.com/NordicHealthData/search-portal.git
+```
 
-   ```composer install```
+__b.__ Install packages using composer by navigating to the project folder and running
 
-__c.__ Copy ```.env.exmaple``` to a new file named ```.env```
+```
+composer install
+```
 
-__d.__ Edit the config (.env)
-    
-    change ELASTICH_SEARCH_HOST to your elastic search host (default localhost:9200)
+__c.__ Copy ```.env.example``` to a new file named ```.env```
 
-__e.__ Start elastic search by running a local instance of Elasticsearch 
-   By running a local copy of elastic search https://www.elastic.co/products/elasticsearch
-   Via docker: https://github.com/dockerfile/elasticsearch 
+__d.__ Edit the configuration file ```.env``` and change ELASTICH_SEARCH_HOST to your Elasticsearch host (default localhost:9200)
 
-## 3. Transform and import records to Elastic Search
+```
+ELASTICH_SEARCH_HOST=yourhost:9200
+```
 
-The portal have built in function to transform DDI into json and put it into Elastic Search.
+__e.__ Start Elasticsearch by running a [local instance of Elasticsearch](https://www.elastic.co/products/elasticsearch) or via [Docker](https://github.com/dockerfile/elasticsearch).
+
+## 3. Transform and import records to Elasticsearch
+
+The portal has built-in functionality to transform DDI into json and put it into Elasticsearch.
 
 ### Transform DDI-XML to json
    
-  You can configure the default location of the source xml-folder in your .env file
-  DDI from SND, NSD, FSD and DDA can be downloaded via http://dev.snd.gu.se/sites/dev.snd.gu.se/files/metadata-2016-03-01.zip
+You can configure the default location of the source xml-folder in your .env file
+DDI from SND, NSD, FSD and DDA can be downloaded via http://dev.snd.gu.se/sites/dev.snd.gu.se/files/metadata-2016-03-01.zip
 
-  Run the transformation
+Run the transformation
 
-  ```php artisan xslt:ddi-to-json {path=null} {outpath=null}```
+```
+php artisan xslt:ddi-to-json {path=null} {outpath=null}
+```
  
 ### Import json document to the index
 
-  You can configure the default location of the json files in your .env file
+You can configure the default location of the json files in your .env file
 
-``php artisan es:ingest-documents path\to\documents``
+```
+php artisan es:ingest-documents path\to\documents
+```
 
 ## Run
 
-There is several ways to run the portal during development or for production. Use one of the following methods.
+There are several ways to run the portal in development or production. Use one of the following methods.
 
 ### Run app using php builtin webserver (the easy way)
-Run:
 
-```php artisan serve```
+```
+php artisan serve
+```
 
 Go to: http://localhost:8000
 
-Make sure you local instance of elastic search is running
+Make sure your local instance of Elasticsearch is running.
 
 ### Using vagrant
- go to the projects root directory
- 
- generate ssh key:
- 
- ```ssh-keygen -t rsa -C "your@email.com"```
 
- run vagrant:
+Go to the root directory of the project and generate a new SSH key
  
- ```vagrant up```
+```
+ssh-keygen -t rsa -C "your@email.com"
+```
+
+Run vagrant
+ 
+```
+vagrant up
+```
  
 ### Using apache
 
- add a site/vhost and point it to the directory ```./search-portal/public``` 
+add a site/vhost and point it to the directory ```./search-portal/public``` 
 
 ### Using docker
 
 ```
- cp .env.example .env
- vim .env
- docker build -t nordichealthportal .
- docker run --name portal -p 80:80 -it nordichealthportal
+cp .env.example .env
+vim .env
+docker build -t nordichealthportal .
+docker run --name portal -p 80:80 -it nordichealthportal
 ```
 
-### Contributors
+## Contributors
+
 * DDA https://www.sa.dk/undervisning-forskning/dda-dansk-data-arkiv
 * FSD http://www.fsd.uta.fi
 * NSD http://nsd.uib.no
 * SND http://snd.gu.se
 
+## License
 
- 
-### License
-
-The Laravel framework is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT)
+This project is licensed under the terms of the [MIT license](http://opensource.org/licenses/MIT).


### PR DESCRIPTION
Several typos in readme have been fixed and several different versions of the name Elasticsearch have also been corrected. License information was not correctly shown on readme either so it was fixed.
